### PR TITLE
feat: add getRootNodeById and getRootParentLayerId API type definitions

### DIFF
--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -350,6 +350,8 @@ declare global {
 
     getNodeById<T extends SceneNode>(id: string): T | null
     getNodeByPosition(position: { x: number; y: number }): SceneNode | null
+    getRootNodeById<T extends SceneNode>(id: string): T | null
+    getRootParentLayerId(id: string): string | null
     createRectangle(): RectangleNode
     createLine(): LineNode
     createEllipse(): EllipseNode

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1269,6 +1269,7 @@ declare global {
     alignSelf: 'STRETCH' | 'INHERIT' // applicable only inside auto-layout frames
     flexGrow: 0 | 1 // applicable only inside auto-layout frames
     rescale(scale: number, scaleOption?: ScaleOption): void
+    resize(width: number, height: number): void
     scaleFactor: number // The default value is 1
     flip(direction: 'VERTICAL' | 'HORIZONTAL'): void
   }


### PR DESCRIPTION
## Summary

新增 MasterGo 插件 API 的 TypeScript 类型定义，支持获取根层级节点及节点尺寸调整。

## Changes

### 新增 API 类型定义

| API | 说明 |
|-----|------|
| `getRootNodeById<T>(id: string): T \| null` | 根据节点 ID 获取其所属的根层级节点（如 Frame、Group 等顶层容器），支持泛型返回 |
| `getRootParentLayerId(id: string): string \| null` | 根据节点 ID 获取其根父层级节点的 ID 字符串 |
| `resize(width: number, height: number): void` | 在 `SceneNode` 上新增 `resize` 方法，支持通过代码调整节点宽高 |

### 变更文件

- `plugin.d.ts`（+3 行）

## Usage

```typescript
// 获取节点的根层级节点
const rootNode = mg.document.getRootNodeById<FrameNode>(nodeId)

// 获取节点的根父层级 ID
const rootParentId = mg.document.getRootParentLayerId(nodeId)

// 调整节点尺寸
node.resize(200, 100)
```