### PR TITLE
feat(types): add WebSocket API type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastergo/plugin-typings",
-  "version": "2.18.1",
+  "version": "2.18.2-beta.0",
   "description": "MasterGo插件API声明文件",
   "type": "module",
   "main": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastergo/plugin-typings",
-  "version": "2.18.3-beta.0",
+  "version": "2.18.4-beta.0",
   "description": "MasterGo插件API声明文件",
   "type": "module",
   "main": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastergo/plugin-typings",
-  "version": "2.18.2-beta.0",
+  "version": "2.18.3-beta.0",
   "description": "MasterGo插件API声明文件",
   "type": "module",
   "main": "",

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1796,6 +1796,7 @@ declare global {
       }
     ): string
     deleteComponentProperty(propertyId: string): void
+    getComponentListVal(): ComponentItemVal[]
   }
 
   type ComponentPropertyValues = Array<ComponentPropertyValue>
@@ -1818,6 +1819,24 @@ declare global {
   }
   type ComponentPropertyOptions = {
     preferredValues?: InstanceSwapPreferredValue[]
+  }
+  type ComponentItemVal = {
+    id: string
+    name: string
+    componentSignature: string
+    cover: string
+    description: string
+    documentationLinks: Array<{ url: string }>
+    height: number
+    width: number
+    isExternal: boolean
+    isHidden: boolean
+    pageId: string
+    pageName: string
+    ukey: string
+    version: number
+    componentNameAlias: string
+    parentId?: string
   }
   type ComponentProperties = {
     name: string

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -315,6 +315,8 @@ declare global {
 
     readonly clientStorage: ClientStorageAPI
 
+    readonly WebSocket: WebSocketAPI
+
     readonly currentUser: User | null
 
     readonly viewport: ViewportAPI
@@ -566,6 +568,29 @@ declare global {
     setAsync(key: string, value: any): Promise<void>
     deleteAsync(key: string): Promise<void>
     keysAsync(): Promise<string[]>
+  }
+
+  interface WebSocketHandle {
+    readonly readyState: number
+    readonly url: string
+    readonly protocol: string
+
+    onopen: ((self: WebSocketHandle, event: { type: string }) => void) | undefined
+    onmessage: ((self: WebSocketHandle, data: any) => void) | undefined
+    onclose: ((self: WebSocketHandle, event: { code: number; reason: string; wasClean: boolean }) => void) | undefined
+    onerror: ((self: WebSocketHandle, event: { type: string }) => void) | undefined
+
+    send(data: any): void
+    close(code?: number, reason?: string): void
+  }
+
+  interface WebSocketAPI {
+    CONNECTING: 0
+    OPEN: 1
+    CLOSING: 2
+    CLOSED: 3
+
+    connect(url: string, protocols?: string | string[]): WebSocketHandle
   }
 
   type ShowUIOptions = {

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -498,6 +498,7 @@ declare global {
     importComponentByKeyAsync(ukey: string): Promise<ComponentNode>
     importComponentSetByKeyAsync(ukey: string): Promise<ComponentSetNode>
     importStyleByKeyAsync(ukey: string): Promise<Style>
+    getComponentListVal(): ComponentItemVal[]
     /**
      * @deprecated
      *
@@ -1796,7 +1797,6 @@ declare global {
       }
     ): string
     deleteComponentProperty(propertyId: string): void
-    getComponentListVal(): ComponentItemVal[]
   }
 
   type ComponentPropertyValues = Array<ComponentPropertyValue>


### PR DESCRIPTION
## 变更摘要

为 plugin-typings 新增 mg.WebSocket API 类型定义，支持插件与本地 MCP 服务间的 WebSocket 通信。

### 提交历史
- 9f7ee75 feat(types): add WebSocket API type definitions

### 文件变更
| 文件 | 变更 |
|------|------|
| plugin.d.ts | +25 -0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)